### PR TITLE
解决强制更新发起安装后弹窗消失的场景

### DIFF
--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -32,9 +32,9 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
 
 //    compile project(':update-app')
-//    compile project(':update-app-kotlin')
+    compile project(':update-app-kotlin')
 
-    compile 'com.qianwen:update-app-kotlin:1.1.0'
+    //compile 'com.qianwen:update-app-kotlin:1.1.0'
     //okgo
     //rxjava 1
     compile 'com.android.support:palette-v7:23.4.0'

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -12,9 +12,17 @@
         android:allowBackup="true"
         android:icon="@mipmap/app_update_logo"
         android:label="@string/app_name"
-
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
+
+        <meta-data
+            android:name="android.max_aspect"
+            android:value="2.1" />
+
+        <meta-data
+            android:name="UPDATE_APP_KEY"
+            android:value="ab55ce55Ac4bcP408cPb8c1Aaeac179c5f6f"/>
+
         <activity android:name=".ui.MainActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
@@ -22,10 +30,6 @@
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
-
-        <meta-data
-            android:name="UPDATE_APP_KEY"
-            android:value="ab55ce55Ac4bcP408cPb8c1Aaeac179c5f6f"/>
 
         <activity android:name=".ui.KotlinActivity">
         </activity>

--- a/sample/src/main/java/com/vector/appupdatedemo/ui/JavaActivity.java
+++ b/sample/src/main/java/com/vector/appupdatedemo/ui/JavaActivity.java
@@ -145,7 +145,7 @@ public class JavaActivity extends AppCompatActivity {
                                     //大小，不设置不显示大小，可以不设置
                                     .setTargetSize(jsonObject.optString("target_size"))
                                     //是否强制更新，可以不设置
-                                    .setConstraint(false)
+                                    .setConstraint(true)
                                     //设置md5，可以不设置
                                     .setNewMd5(jsonObject.optString("new_md51"));
                         } catch (JSONException e) {

--- a/update-app-kotlin/build.gradle
+++ b/update-app-kotlin/build.gradle
@@ -35,8 +35,8 @@ dependencies {
 
     compile "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
 
-    compile 'com.qianwen:update-app:+'
-//    compile project(':update-app')
+    //compile 'com.qianwen:update-app:+'
+    compile project(':update-app')
 }
 //添加
 publish {

--- a/update-app/src/main/java/com/vector/update_app/UpdateDialogFragment.java
+++ b/update-app/src/main/java/com/vector/update_app/UpdateDialogFragment.java
@@ -356,9 +356,22 @@ public class UpdateDialogFragment extends DialogFragment implements View.OnClick
                 }
 
                 @Override
-                public boolean onFinish(File file) {
+                public boolean onFinish(final File file) {
                     if (!UpdateDialogFragment.this.isRemoving()) {
-                        dismissAllowingStateLoss();
+                        if (mUpdateApp.isConstraint()) {
+                            mNumberProgressBar.setVisibility(View.GONE);
+                            mUpdateOkButton.setText("安装");
+                            mUpdateOkButton.setVisibility(View.VISIBLE);
+                            mUpdateOkButton.setOnClickListener(new View.OnClickListener() {
+                                @Override
+                                public void onClick(View v) {
+                                    AppUpdateUtils.installApp(getActivity(), file);
+                                }
+                            });
+                        }
+                        else {
+                            dismissAllowingStateLoss();
+                        }
                     }
                     return true;
                 }


### PR DESCRIPTION
强制更新时当下载完成发起安装时弹窗会消失，如果这个时候用户取消安装，切回来还是可以正常使用的