### PR TITLE
给插件使用者更多的配置和开启一些钩子方便适配不同的业务需求

### DIFF
--- a/sample/src/main/java/com/vector/appupdatedemo/ui/JavaActivity.java
+++ b/sample/src/main/java/com/vector/appupdatedemo/ui/JavaActivity.java
@@ -127,15 +127,17 @@ public class JavaActivity extends AppCompatActivity {
                         UpdateAppBean updateAppBean = new UpdateAppBean();
                         try {
                             JSONObject jsonObject = new JSONObject(json);
+                            final String newVersion = jsonObject.optString("new_version");
                             updateAppBean
                                     //（必须）是否更新Yes,No
                                     .setUpdate(jsonObject.optString("update"))
                                     //（必须）新版本号，
-                                    .setNewVersion(jsonObject.optString("new_version"))
+                                    .setNewVersion(newVersion)
                                     //（必须）下载地址
                                     .setApkFileUrl(jsonObject.optString("apk_file_url"))
                                     //测试下载路径是重定向路径
 //                                    .setApkFileUrl("http://openbox.mobilem.360.cn/index/d/sid/3282847")
+//                                    .setUpdateDefDialogTitle(String.format("AppUpdate 是否升级到%s版本？", newVersion))
                                     //（必须）更新内容
 //                                    .setUpdateLog(jsonObject.optString("update_log"))
                                     //测试内容过度

--- a/update-app/src/main/java/com/vector/update_app/UpdateAppBean.java
+++ b/update-app/src/main/java/com/vector/update_app/UpdateAppBean.java
@@ -27,6 +27,8 @@ public class UpdateAppBean implements Serializable {
     private String apk_file_url;
     //更新日志
     private String update_log;
+    //配置默认更新dialog 的title
+    private String update_def_dialog_title;
     //新app大小
     private String target_size;
     //是否强制更新
@@ -35,6 +37,8 @@ public class UpdateAppBean implements Serializable {
     private String new_md5;
     //是否增量 暂时不用
     private boolean delta;
+    //服务器端的原生返回数据（json）,方便使用者在hasNewApp自定义渲染dialog的时候可以有别的控制，比如：#issues/59
+    private String origin_res;
     /**********以下是内部使用的数据**********/
 
     //网络工具，内部使用
@@ -120,6 +124,14 @@ public class UpdateAppBean implements Serializable {
         return this;
     }
 
+    public String getUpdateDefDialogTitle() {
+        return update_def_dialog_title;
+    }
+
+    public void setUpdateDefDialogTitle(String updateDefDialogTitle) {
+        this.update_def_dialog_title = updateDefDialogTitle;
+    }
+
     public boolean isDelta() {
         return delta;
     }
@@ -170,4 +182,11 @@ public class UpdateAppBean implements Serializable {
         mOnlyWifi = onlyWifi;
     }
 
+    public String getOriginRes() {
+        return origin_res;
+    }
+
+    public void setOriginRes(String originRes) {
+        this.origin_res = originRes;
+    }
 }

--- a/update-app/src/main/java/com/vector/update_app/UpdateAppManager.java
+++ b/update-app/src/main/java/com/vector/update_app/UpdateAppManager.java
@@ -246,7 +246,7 @@ public class UpdateAppManager {
                 @Override
                 public void onError(String error) {
                     callback.onAfter();
-                    callback.noNewApp();
+                    callback.noNewApp(error);
                 }
             });
         } else {
@@ -262,7 +262,7 @@ public class UpdateAppManager {
                 @Override
                 public void onError(String error) {
                     callback.onAfter();
-                    callback.noNewApp();
+                    callback.noNewApp(error);
                 }
             });
         }
@@ -316,11 +316,11 @@ public class UpdateAppManager {
                 //没有则进行下载，监听下载完成，弹出安装对话框
 
             } else {
-                callback.noNewApp();
+                callback.noNewApp("没有新版本");
             }
         } catch (Exception ignored) {
             ignored.printStackTrace();
-            callback.noNewApp();
+            callback.noNewApp(String.format("解析自定义更新配置消息出错[%s]", ignored.getMessage()));
         }
     }
 

--- a/update-app/src/main/java/com/vector/update_app/UpdateCallback.java
+++ b/update-app/src/main/java/com/vector/update_app/UpdateCallback.java
@@ -49,8 +49,9 @@ public class UpdateCallback {
 
     /**
      * 没有新版本
+     * @param error HttpManager实现类请求出错返回的错误消息，交给使用者自己返回，有可能不同的应用错误内容需要提示给客户
      */
-    protected void noNewApp() {
+    protected void noNewApp(String error) {
     }
 
     /**

--- a/update-app/src/main/java/com/vector/update_app/UpdateDialogFragment.java
+++ b/update-app/src/main/java/com/vector/update_app/UpdateDialogFragment.java
@@ -163,9 +163,10 @@ public class UpdateDialogFragment extends DialogFragment implements View.OnClick
 
         if (mUpdateApp != null) {
             //弹出对话框
-            String newVersion = mUpdateApp.getNewVersion();
-            String targetSize = mUpdateApp.getTargetSize();
-            String updateLog = mUpdateApp.getUpdateLog();
+            final String dialogTitle = mUpdateApp.getUpdateDefDialogTitle();
+            final String newVersion = mUpdateApp.getNewVersion();
+            final String targetSize = mUpdateApp.getTargetSize();
+            final String updateLog = mUpdateApp.getUpdateLog();
 
             String msg = "";
 
@@ -180,7 +181,7 @@ public class UpdateDialogFragment extends DialogFragment implements View.OnClick
             //更新内容
             mContentTextView.setText(msg);
             //标题
-            mTitleTextView.setText(String.format("是否升级到%s版本？", newVersion));
+            mTitleTextView.setText(TextUtils.isEmpty(dialogTitle) ? String.format("是否升级到%s版本？", newVersion) : dialogTitle);
             //强制更新
             if (mUpdateApp.isConstraint()) {
                 mLlClose.setVisibility(View.GONE);


### PR DESCRIPTION
因为我们的应用是一个原生加h5的混合应用，在更新的时候，后端会同时返回h5的更新记录，和对应的版本号，为了实现某些灵活的需求，所以提请了这个pr，请@WVector帮忙看一下，可以的话请合并一下，这样其实插件我觉得某些方面会更加灵活，我修改的重点是：
1. 针对【UpdateAppBean】新增update_def_dialog_title字段，方便用户自定义默认的升级dialog提示title
2.针对【UpdateAppBean && UpdateDialogFragment.java】新增origin_res字段，存放服务器端的原生返回数据（json）,方便使用者在hasNewApp自定义渲染dialog的时候可以有别的控制，比如：#issues/59
比如:
```java
@Override
            protected void hasNewApp(UpdateAppBean updateApp, UpdateAppManager updateAppManager) {
                 //如果有了origin_res，那么我就可以灵活在这里控制是否需要做一些其他处理
                // TODO 等待作者合并代码
                final boolean appHasNewVer = false;
                final boolean h5HasNewVer = true;
                final String content = updateApp.getUpdateLog();
                if (appHasNewVer) {
                    updateAppManager.showDialogFragment();
                } else if (h5HasNewVer) {
                    DialogUtil.dialog(activity,"免流量更新提示", content, (appUpdateDialogChangeListener::onH5UpdateDialogPositive)).show();
                }
            }
```
3.针对【UpdateAppManager.java & UpdateCallback.java】将HttpManager实现类请求出错返回的错误消息，交给使用者自己返回，有可能不同的应用错误内容需要提示给客户

写完之后由于时间原因，我还没有测试，有不对的麻烦指正，下次我会先测过在提交，不好意思，项目太紧，谢谢啦