### PR TITLE
解决使用默认的UpdateDialogFragment在初次安装应用时候，因为DownloadService没有能使用activity.s…

### DIFF
--- a/update-app/src/main/java/com/vector/update_app/SilenceUpdateCallback.java
+++ b/update-app/src/main/java/com/vector/update_app/SilenceUpdateCallback.java
@@ -53,6 +53,11 @@ public class SilenceUpdateCallback extends UpdateCallback {
                 public void onError(String msg) {
 
                 }
+
+                @Override
+                public boolean onInstallAppAndAppOnForeground(File file) {
+                    return false;
+                }
             });
         }
     }

--- a/update-app/src/main/java/com/vector/update_app/UpdateDialogFragment.java
+++ b/update-app/src/main/java/com/vector/update_app/UpdateDialogFragment.java
@@ -387,6 +387,7 @@ public class UpdateDialogFragment extends DialogFragment implements View.OnClick
                                 @Override
                                 public void onClick(View v) {
                                     AppUpdateUtils.installApp(UpdateDialogFragment.this, file);
+                                    dismiss();
                                 }
                             });
                         } else {
@@ -401,6 +402,14 @@ public class UpdateDialogFragment extends DialogFragment implements View.OnClick
                     if (!UpdateDialogFragment.this.isRemoving()) {
                         dismissAllowingStateLoss();
                     }
+                }
+
+                @Override
+                public boolean onInstallAppAndAppOnForeground(File file) {
+                    // 如果应用处于前台，那么就自行处理应用安装
+                    AppUpdateUtils.installApp(UpdateDialogFragment.this.getActivity(), file);
+                    dismiss();
+                    return true;
                 }
             });
         }

--- a/update-app/src/main/java/com/vector/update_app/service/DownloadService.java
+++ b/update-app/src/main/java/com/vector/update_app/service/DownloadService.java
@@ -189,6 +189,14 @@ public class DownloadService extends Service {
          * @param msg 异常信息
          */
         void onError(String msg);
+
+        /**
+         * 当应用处于前台，准备执行安装程序时候的回调，
+         *
+         * @param file
+         * @return
+         */
+        boolean onInstallAppAndAppOnForeground(File file);
     }
 
     /**
@@ -283,7 +291,10 @@ public class DownloadService extends Service {
                 if (AppUpdateUtils.isAppOnForeground(DownloadService.this) || mBuilder == null) {
                     //App前台运行
                     mNotificationManager.cancel(NOTIFY_ID);
-                    AppUpdateUtils.installApp(DownloadService.this, file);
+                    boolean temp = mCallBack.onInstallAppAndAppOnForeground(file);
+                    if (!temp) {
+                        AppUpdateUtils.installApp(DownloadService.this, file);
+                    }
                 } else {
                     //App后台运行
                     //更新参数,注意flags要使用FLAG_UPDATE_CURRENT

--- a/update-app/src/main/java/com/vector/update_app/utils/AppUpdateUtils.java
+++ b/update-app/src/main/java/com/vector/update_app/utils/AppUpdateUtils.java
@@ -96,6 +96,28 @@ public class AppUpdateUtils {
         return false;
     }
 
+    public static boolean installApp(Activity activity, File appFile) {
+        try {
+            Intent intent = new Intent(Intent.ACTION_VIEW);
+            intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                Uri fileUri = FileProvider.getUriForFile(activity, activity.getApplicationContext().getPackageName() + ".fileProvider", appFile);
+                intent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+                intent.setDataAndType(fileUri, "application/vnd.android.package-archive");
+            } else {
+                intent.setDataAndType(Uri.fromFile(appFile), "application/vnd.android.package-archive");
+            }
+            if (activity.getPackageManager().queryIntentActivities(intent, 0).size() > 0) {
+                activity.startActivityForResult(intent, REQ_CODE_INSTALL_APP);
+            }
+            return true;
+        } catch (Exception e) {
+            // TODO 后续可以考虑这种情况应该通知应用开发者
+            e.printStackTrace();
+        }
+        return false;
+    }
+
     public static boolean installApp(Fragment fragment, File appFile) {
         try {
             final Activity activity = fragment.getActivity();


### PR DESCRIPTION
解决使用默认的UpdateDialogFragment在初 次安装应用时候，因为DownloadService没有能使用activity.startActivityForResult启动安装界面，导致用户如果取消安装，插件使用者得不到通知的问题:

```java
private void startDownload(UpdateAppBean updateApp, final DownloadCallback callback) {

        mDismissNotificationProgress = updateApp.isDismissNotificationProgress();

        String apkUrl = updateApp.getApkFileUrl();
        if (TextUtils.isEmpty(apkUrl)) {
            String contentText = "新版本下载路径错误";
            stop(contentText);
            return;
        }
        String appName = AppUpdateUtils.getApkName(updateApp);

        File appDir = new File(updateApp.getTargetPath());
        if (!appDir.exists()) {
            appDir.mkdirs();
        }

        String target = appDir + File.separator + updateApp.getNewVersion();

        updateApp.getHttpManager().download(apkUrl, target, appName, new FileDownloadCallBack(callback));
    }

    private void stop(String contentText) {
        if (mBuilder != null) {
            mBuilder.setContentTitle(AppUpdateUtils.getAppName(DownloadService.this)).setContentText(contentText);
            Notification notification = mBuilder.build();
            notification.flags = Notification.FLAG_AUTO_CANCEL;
            mNotificationManager.notify(NOTIFY_ID, notification);
        }
        close();
    }

    private void close() {
        stopSelf();
        isRunning = false;
    }

    /**
     * 进度条回调接口
     */
    public interface DownloadCallback {
       // 新增下面的回调口子
        /**
         * 当应用处于前台，准备执行安装程序时候的回调，
         *
         * @param file
         * @return
         */
        boolean onInstallAppAndAppOnForeground(File file);
    }
```

在初次应用下载完毕：
```java
 @Override
        public void onResponse(File file) {
            if (mCallBack != null) {
                if (!mCallBack.onFinish(file)) {
                    close();
                    return;
                }
            }

            try {

                if (AppUpdateUtils.isAppOnForeground(DownloadService.this) || mBuilder == null) {
                    //App前台运行
                    mNotificationManager.cancel(NOTIFY_ID);
                    **// 给应用开发者相应的权限去控制，是否自己处理**
                    boolean temp = mCallBack.onInstallAppAndAppOnForeground(file);
                    if (!temp) {
                        AppUpdateUtils.installApp(DownloadService.this, file);
                    }
```

比如，在默认的`UpdateDialogFragment`中：
```java
 /**
     * 回调监听下载
     */
    private void startDownloadApp(DownloadService.DownloadBinder binder) {
        // 开始下载，监听下载进度，可以用对话框显示
        if (mUpdateApp != null) {

            binder.start(mUpdateApp, new DownloadService.DownloadCallback() {
               //....

                **@Override
                public boolean onInstallAppAndAppOnForeground(File file) {
                    // 如果应用处于前台，那么就自行处理应用安装
                    AppUpdateUtils.installApp(UpdateDialogFragment.this.getActivity(), file);
                    dismiss();
                    return true;
                }**
            });
        }
    }
```

这样插件使用者就能得到用户取消安装应用的通知：
```java
@Override
    public void onActivityResult(int requestCode, int resultCode, Intent data) {
        switch (resultCode) {
            case Activity.RESULT_OK:
                break;
            **case Activity.DEFAULT_KEYS_DIALER:
                switch (requestCode){
                    // 得到通过UpdateDialogFragment默认dialog方式安装，用户取消安装的回调通知，以便用户自己去判断，比如这个更新如果是强制的，但是用户下载之后取消了，在这里发起相应的操作
                    case AppUpdateUtils.REQ_CODE_INSTALL_APP:
                        Toast.makeText(this,"用户取消了安装包的更新", Toast.LENGTH_LONG).show();
                        break;
                }
                break;**
            case Activity.RESULT_CANCELED:
                break;
            default:
        }
    }
```


