### PR TITLE
解决用户还没有点击更新，就去动mDownloadBinder，导致的空指针bug

### DIFF
--- a/update-app/src/main/java/com/vector/update_app/UpdateDialogFragment.java
+++ b/update-app/src/main/java/com/vector/update_app/UpdateDialogFragment.java
@@ -311,7 +311,10 @@ public class UpdateDialogFragment extends DialogFragment implements View.OnClick
     }
 
     public void cancelDownloadService() {
-        mDownloadBinder.stop("取消下载");
+        if (mDownloadBinder != null) {
+            // 标识用户已经点击了更新，之后点击取消
+            mDownloadBinder.stop("取消下载");
+        }
     }
 
     private void installApp() {


### PR DESCRIPTION
昨天修出了一个bug，不好意思，麻烦再帮忙合并一下：
解决下面的空指针，昨天太晚了，只盯着那个问题测试了。

```cmd
04-07 16:16:30.942 28268-28268/com.csii.mobilebank E/AndroidRuntime: FATAL EXCEPTION: main
    Process: com.csii.mobilebank, PID: 28268
    java.lang.NullPointerException: Attempt to invoke virtual method 'void com.vector.update_app.service.DownloadService$DownloadBinder.stop(java.lang.String)' on a null object reference
        at com.vector.update_app.UpdateDialogFragment.cancelDownloadService(UpdateDialogFragment.java:314)
        at com.vector.update_app.UpdateDialogFragment.onClick(UpdateDialogFragment.java:301)
        at android.view.View.performClick(View.java:6291)
        at android.view.View$PerformClick.run(View.java:24931)
        at android.os.Handler.handleCallback(Handler.java:808)
        at android.os.Handler.dispatchMessage(Handler.java:101)
        at android.os.Looper.loop(Looper.java:166)
        at android.app.ActivityThread.main(ActivityThread.java:7406)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.Zygote$MethodAndArgsCaller.run(Zygote.java:245)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:926)
```